### PR TITLE
Publish fork to Coralogix registry

### DIFF
--- a/.github/workflows/publish-target-allocator.yaml
+++ b/.github/workflows/publish-target-allocator.yaml
@@ -45,8 +45,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            otel/target-allocator
-            ghcr.io/open-telemetry/opentelemetry-operator/target-allocator
+            coralogixrepo/target-allocator
           tags: |
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
@@ -71,16 +70,8 @@ jobs:
         uses: docker/login-action@v3
         if: ${{ github.event_name == 'push' }}
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Login to GitHub Package Registry
-        uses: docker/login-action@v3
-        if: ${{ github.event_name == 'push' }}
-        with:
-          registry: ghcr.io
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Adjust the GH workflow to publish the fork to Coralogix DockerHub registry.
